### PR TITLE
feat: FeignClient 구성 및 예시 코드 추가

### DIFF
--- a/first-server/build.gradle
+++ b/first-server/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/first-server/src/main/java/com/hanhwa_tae/firstserver/FirstServerApplication.java
+++ b/first-server/src/main/java/com/hanhwa_tae/firstserver/FirstServerApplication.java
@@ -2,7 +2,9 @@ package com.hanhwa_tae.firstserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class FirstServerApplication {
 

--- a/first-server/src/main/java/com/hanhwa_tae/firstserver/client/UserClient.java
+++ b/first-server/src/main/java/com/hanhwa_tae/firstserver/client/UserClient.java
@@ -1,0 +1,15 @@
+package com.hanhwa_tae.firstserver.client;
+
+import com.hanhwa_tae.firstserver.common.dto.ApiResponse;
+import com.hanhwa_tae.firstserver.config.FeignClientConfig;
+import com.hanhwa_tae.firstserver.feignexample.dto.response.UserInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "auth-server", configuration = FeignClientConfig.class)
+public interface UserClient {
+
+    @GetMapping("/users/info")
+    ApiResponse<UserInfoResponse> getUserInfo();
+
+}

--- a/first-server/src/main/java/com/hanhwa_tae/firstserver/config/FeignClientConfig.java
+++ b/first-server/src/main/java/com/hanhwa_tae/firstserver/config/FeignClientConfig.java
@@ -1,0 +1,29 @@
+package com.hanhwa_tae.firstserver.config;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignClientConfig {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+
+            ServletRequestAttributes requestAttributes =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+            if(requestAttributes != null){
+                String userNo = requestAttributes.getRequest().getHeader("X-User-No");
+                String userId = requestAttributes.getRequest().getHeader("X-User-Id");
+                String userRank = requestAttributes.getRequest().getHeader("X-User-Rank");
+                requestTemplate.header("X-User-No", userNo);
+                requestTemplate.header("X-User-Id", userId);
+                requestTemplate.header("X-User-Rank", userRank);
+
+            }
+        };
+    }
+}

--- a/first-server/src/main/java/com/hanhwa_tae/firstserver/feignexample/controller/FeignController.java
+++ b/first-server/src/main/java/com/hanhwa_tae/firstserver/feignexample/controller/FeignController.java
@@ -1,0 +1,26 @@
+package com.hanhwa_tae.firstserver.feignexample.controller;
+
+
+import com.hanhwa_tae.firstserver.common.dto.ApiResponse;
+import com.hanhwa_tae.firstserver.feignexample.service.FeignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feign")
+public class FeignController {
+
+    private final FeignService feignService;
+
+    @GetMapping("/user-info")
+    public ResponseEntity<ApiResponse<Void>> getUserInfo(){
+        feignService.getUserInfo();
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+
+    }
+}

--- a/first-server/src/main/java/com/hanhwa_tae/firstserver/feignexample/dto/response/UserInfoResponse.java
+++ b/first-server/src/main/java/com/hanhwa_tae/firstserver/feignexample/dto/response/UserInfoResponse.java
@@ -1,0 +1,33 @@
+package com.hanhwa_tae.firstserver.feignexample.dto.response;
+
+import com.hanhwa_tae.firstserver.common.dto.GenderType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+    private final String userId;
+
+    private final String username;
+    private final String email;
+    private final GenderType gender;
+    private final Date birth;
+    private final String phone;
+    private final String address;
+
+    @Override
+    public String toString() {
+        return "UserInfoResponse{" +
+                "userId='" + userId + '\'' +
+                ", username='" + username + '\'' +
+                ", email='" + email + '\'' +
+                ", gender=" + gender +
+                ", birth=" + birth +
+                ", phone='" + phone + '\'' +
+                ", address='" + address + '\'' +
+                '}';
+    }
+}

--- a/first-server/src/main/java/com/hanhwa_tae/firstserver/feignexample/service/FeignService.java
+++ b/first-server/src/main/java/com/hanhwa_tae/firstserver/feignexample/service/FeignService.java
@@ -1,0 +1,19 @@
+package com.hanhwa_tae.firstserver.feignexample.service;
+
+import com.hanhwa_tae.firstserver.client.UserClient;
+import com.hanhwa_tae.firstserver.feignexample.dto.response.UserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FeignService {
+    private final UserClient userClient;
+
+    public void getUserInfo() {
+        UserInfoResponse response = userClient.getUserInfo().getData();
+        log.info(response.toString());
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ㅌ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/feign-> dev

### 변경 사항
feign client를 통해 commerce -> auth 서버로의 통신 구성
임시로 유저 정보를 가져오는 테스트를 commerce server의  feignexampe 폴더에 구성 했으니 확인하고 코드 작성 해주시면 됩니다!
